### PR TITLE
Simplify TranslateOperator implementation across all drivers

### DIFF
--- a/drivers/clickhouse/clickhouse.go
+++ b/drivers/clickhouse/clickhouse.go
@@ -8,17 +8,27 @@ import (
 	"github.com/pseudomuto/where"
 )
 
-var supportsFeatures = []string{
-	"ARRAY",
-	"FINAL",
-	"GLOBAL",
-	"ILIKE",
-	"JSON",
-	"PREWHERE",
-	"SAMPLE",
-	"TUPLE",
-	"WITH",
-}
+var (
+	supportedFeatures = []string{
+		"ARRAY",
+		"FINAL",
+		"GLOBAL",
+		"ILIKE",
+		"JSON",
+		"PREWHERE",
+		"SAMPLE",
+		"TUPLE",
+		"WITH",
+	}
+
+	supportedOperations = []string{
+		"=", "!=", "<>", "<", ">", "<=", ">=",
+		"LIKE", "NOT LIKE", "ILIKE", "NOT ILIKE",
+		"IN", "NOT IN",
+		"IS NULL", "IS NOT NULL",
+		"BETWEEN", "NOT BETWEEN",
+	}
+)
 
 type (
 	// ClickHouseDriver implements the where.Driver interface for ClickHouse databases.
@@ -87,24 +97,15 @@ func (d *ClickHouseDriver) Keywords() []string {
 
 func (d *ClickHouseDriver) TranslateOperator(op string) (string, bool) {
 	upperOp := strings.ToUpper(op)
-	switch upperOp {
-	case "=", "!=", "<>", "<", ">", "<=", ">=":
-		return op, true
-	case "LIKE", "NOT LIKE", "ILIKE", "NOT ILIKE":
+	if slices.Contains(supportedOperations, upperOp) {
 		return upperOp, true
-	case "IN", "NOT IN":
-		return upperOp, true
-	case "IS NULL", "IS NOT NULL":
-		return upperOp, true
-	case "BETWEEN", "NOT BETWEEN":
-		return upperOp, true
-	default:
-		return "", false
 	}
+
+	return "", false
 }
 
 func (d *ClickHouseDriver) SupportsFeature(feature string) bool {
-	return slices.Contains(supportsFeatures, strings.ToUpper(feature))
+	return slices.Contains(supportedFeatures, strings.ToUpper(feature))
 }
 
 func init() {

--- a/drivers/mysql/mysql.go
+++ b/drivers/mysql/mysql.go
@@ -8,13 +8,23 @@ import (
 	"github.com/pseudomuto/where"
 )
 
-var supportedFeatures = []string{
-	"CTE",
-	"FULLTEXT",
-	"JSON",
-	"PARTITION",
-	"SPATIAL",
-}
+var (
+	supportedFeatures = []string{
+		"CTE",
+		"FULLTEXT",
+		"JSON",
+		"PARTITION",
+		"SPATIAL",
+	}
+
+	supportedOperations = []string{
+		"=", "!=", "<>", "<", ">", "<=", ">=",
+		"LIKE", "NOT LIKE",
+		"IN", "NOT IN",
+		"IS NULL", "IS NOT NULL",
+		"BETWEEN", "NOT BETWEEN",
+	}
+)
 
 type (
 	// MySQLDriver implements the where.Driver interface for MySQL and MariaDB databases.
@@ -83,24 +93,15 @@ func (d *MySQLDriver) Keywords() []string {
 
 func (d *MySQLDriver) TranslateOperator(op string) (string, bool) {
 	upperOp := strings.ToUpper(op)
-	switch upperOp {
-	case "=", "!=", "<>", "<", ">", "<=", ">=":
-		return op, true
-	case "LIKE", "NOT LIKE":
+	if slices.Contains(supportedOperations, upperOp) {
 		return upperOp, true
-	case "ILIKE":
-		return "LIKE", true
-	case "NOT ILIKE":
-		return "NOT LIKE", true
-	case "IN", "NOT IN":
-		return upperOp, true
-	case "IS NULL", "IS NOT NULL":
-		return upperOp, true
-	case "BETWEEN", "NOT BETWEEN":
-		return upperOp, true
-	default:
-		return "", false
 	}
+
+	if upperOp == "ILIKE" || upperOp == "NOT ILIKE" {
+		return strings.Replace(upperOp, "ILIKE", "LIKE", 1), true
+	}
+
+	return "", false
 }
 
 func (d *MySQLDriver) SupportsFeature(feature string) bool {

--- a/drivers/postgres/postgres.go
+++ b/drivers/postgres/postgres.go
@@ -8,15 +8,25 @@ import (
 	"github.com/pseudomuto/where"
 )
 
-var supportedFeatures = []string{
-	"ARRAY",
-	"CTE",
-	"ILIKE",
-	"JSON",
-	"JSONB",
-	"RETURNING",
-	"WINDOW",
-}
+var (
+	supportedFeatures = []string{
+		"ARRAY",
+		"CTE",
+		"ILIKE",
+		"JSON",
+		"JSONB",
+		"RETURNING",
+		"WINDOW",
+	}
+
+	supportedOperations = []string{
+		"=", "!=", "<>", "<", ">", "<=", ">=",
+		"LIKE", "NOT LIKE", "ILIKE", "NOT ILIKE",
+		"IN", "NOT IN",
+		"IS NULL", "IS NOT NULL",
+		"BETWEEN", "NOT BETWEEN",
+	}
+)
 
 type (
 	// PostgreSQLDriver implements the where.Driver interface for PostgreSQL databases.
@@ -85,20 +95,11 @@ func (d *PostgreSQLDriver) Keywords() []string {
 
 func (d *PostgreSQLDriver) TranslateOperator(op string) (string, bool) {
 	upperOp := strings.ToUpper(op)
-	switch upperOp {
-	case "=", "!=", "<>", "<", ">", "<=", ">=":
-		return op, true
-	case "LIKE", "NOT LIKE", "ILIKE", "NOT ILIKE":
+	if slices.Contains(supportedOperations, upperOp) {
 		return upperOp, true
-	case "IN", "NOT IN":
-		return upperOp, true
-	case "IS NULL", "IS NOT NULL":
-		return upperOp, true
-	case "BETWEEN", "NOT BETWEEN":
-		return upperOp, true
-	default:
-		return "", false
 	}
+
+	return "", false
 }
 
 func (d *PostgreSQLDriver) SupportsFeature(feature string) bool {


### PR DESCRIPTION
Replace switch statements with slice-based lookups for better maintainability and consistency. Adds supportedOperations slice to each driver following the same pattern as supportedFeatures.